### PR TITLE
Add Azure VM module with trusted launch defaults

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -427,3 +427,40 @@
 #     "Unidad de Negocio" = "Xpertal"
 #   }
 # }
+
+## == Ejemplo de declarar el modulo de virtual machine ==
+
+# module "virtual_machine_web" {
+#   source = "./modules/virtual_machine"
+#
+#   vm_name             = "xpeterraformpoc-web-01"
+#   resource_group_name = module.resource_group_xpeterraformpoc2.resource_group_name
+#   location            = module.resource_group_xpeterraformpoc2.resource_group_location
+#   vm_size             = "Standard_DS2_v2"
+#   os_type             = "linux"
+#   admin_username      = "azureuser"
+#   admin_password      = "C0mpleja!1234"
+#
+#   subnet_id = module.vnet_xpeterraformpoc2.subnet_ids["web"]
+#
+#   # Las VMs nacen sin IP pública; habilita esta bandera solo si es necesario.
+#   enable_public_ip = false
+#
+#   network_security_group_id = module.network_security_group.nsg_id
+#
+#   source_image_id = "/subscriptions/<SUB_SIG>/resourceGroups/<RG_SIG>/providers/Microsoft.Compute/galleries/<GALLERY>/images/<IMAGE>/versions/<VERSION>"
+#
+#   tags = {
+#     UDN      = "Xpertal"
+#     OWNER    = "Equipo Infra"
+#     xpeowner = "infra@xpertal.com"
+#     proyecto = "terraform"
+#     ambiente = "dev"
+#   }
+#
+#   providers = {
+#     azurerm = azurerm.xpe_shared_poc
+#   }
+# }
+
+## =================================================================== ##

--- a/modules/virtual_machine/main.tf
+++ b/modules/virtual_machine/main.tf
@@ -1,0 +1,117 @@
+locals {
+  effective_private_ip_allocation = var.private_ip_address != null ? "Static" : var.private_ip_address_allocation
+}
+
+resource "azurerm_public_ip" "this" {
+  count               = var.enable_public_ip ? 1 : 0
+  name                = "${var.vm_name}-pip"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  allocation_method   = var.public_ip_allocation_method
+  sku                 = var.public_ip_sku
+  domain_name_label   = var.public_ip_domain_name_label
+
+  tags = tomap(var.tags)
+}
+
+resource "azurerm_network_interface" "this" {
+  name                = "${var.vm_name}-nic"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = var.subnet_id
+    private_ip_address_allocation = local.effective_private_ip_allocation
+    private_ip_address            = var.private_ip_address
+    public_ip_address_id          = var.enable_public_ip ? azurerm_public_ip.this[0].id : null
+  }
+
+  tags = tomap(var.tags)
+}
+
+resource "azurerm_network_interface_security_group_association" "this" {
+  count = var.network_security_group_id != null ? 1 : 0
+
+  network_interface_id      = azurerm_network_interface.this.id
+  network_security_group_id = var.network_security_group_id
+}
+
+resource "azurerm_linux_virtual_machine" "this" {
+  count = lower(var.os_type) == "linux" ? 1 : 0
+
+  name                = var.vm_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  size                = var.vm_size
+
+  admin_username                  = var.admin_username
+  admin_password                  = var.admin_password
+  disable_password_authentication = false
+  network_interface_ids           = [azurerm_network_interface.this.id]
+
+  os_disk {
+    name                 = "${var.vm_name}-osdisk"
+    caching              = var.os_disk.caching
+    storage_account_type = var.os_disk.storage_account_type
+    disk_size_gb         = var.os_disk.disk_size_gb
+  }
+
+  source_image_id = var.source_image_id
+
+  secure_boot_enabled = true
+  vtpm_enabled        = true
+  security_type       = "TrustedLaunch"
+
+  tags = tomap(var.tags)
+
+  lifecycle {
+    precondition {
+      condition     = var.admin_password != null && trim(var.admin_password) != ""
+      error_message = "Debes proporcionar admin_password para las máquinas Linux."
+    }
+    precondition {
+      condition     = var.source_image_id != null && trim(var.source_image_id) != ""
+      error_message = "Debes proporcionar source_image_id con la ruta de Azure Compute Gallery."
+    }
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "this" {
+  count = lower(var.os_type) == "windows" ? 1 : 0
+
+  name                = var.vm_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  size                = var.vm_size
+
+  admin_username     = var.admin_username
+  admin_password     = var.admin_password
+  network_interface_ids = [azurerm_network_interface.this.id]
+
+  os_disk {
+    name                 = "${var.vm_name}-osdisk"
+    caching              = var.os_disk.caching
+    storage_account_type = var.os_disk.storage_account_type
+    disk_size_gb         = var.os_disk.disk_size_gb
+  }
+
+  source_image_id = var.source_image_id
+
+  secure_boot_enabled = true
+  vtpm_enabled        = true
+  security_type       = "TrustedLaunch"
+
+  tags = tomap(var.tags)
+
+  lifecycle {
+    precondition {
+      condition     = var.admin_password != null && trim(var.admin_password) != ""
+      error_message = "Debes proporcionar admin_password para las máquinas Windows."
+    }
+    precondition {
+      condition     = var.source_image_id != null && trim(var.source_image_id) != ""
+      error_message = "Debes proporcionar source_image_id con la ruta de Azure Compute Gallery."
+    }
+  }
+}

--- a/modules/virtual_machine/outputs.tf
+++ b/modules/virtual_machine/outputs.tf
@@ -1,0 +1,29 @@
+output "vm_id" {
+  description = "ID de la máquina virtual."
+  value       = try(azurerm_linux_virtual_machine.this[0].id, azurerm_windows_virtual_machine.this[0].id)
+}
+
+output "vm_name" {
+  description = "Nombre de la máquina virtual."
+  value       = var.vm_name
+}
+
+output "network_interface_id" {
+  description = "ID de la NIC principal."
+  value       = azurerm_network_interface.this.id
+}
+
+output "private_ip_address" {
+  description = "IP privada asignada."
+  value       = try(azurerm_network_interface.this.ip_configuration[0].private_ip_address, null)
+}
+
+output "public_ip_id" {
+  description = "ID de la IP pública (si se creó)."
+  value       = try(azurerm_public_ip.this[0].id, null)
+}
+
+output "public_ip_address" {
+  description = "Dirección IP pública (si existe)."
+  value       = try(azurerm_public_ip.this[0].ip_address, null)
+}

--- a/modules/virtual_machine/variables.tf
+++ b/modules/virtual_machine/variables.tf
@@ -1,0 +1,116 @@
+variable "vm_name" {
+  description = "Nombre de la máquina virtual."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource Group donde se creará la VM."
+  type        = string
+}
+
+variable "location" {
+  description = "Región/Location de la VM."
+  type        = string
+}
+
+variable "vm_size" {
+  description = "SKU/tamaño de la VM (por ejemplo, Standard_DS2_v2)."
+  type        = string
+}
+
+variable "os_type" {
+  description = "Sistema operativo: \"linux\" o \"windows\"."
+  type        = string
+
+  validation {
+    condition     = contains(["linux", "windows"], lower(var.os_type))
+    error_message = "os_type debe ser \"linux\" o \"windows\"."
+  }
+}
+
+variable "admin_username" {
+  description = "Usuario administrador."
+  type        = string
+}
+
+variable "admin_password" {
+  description = "Contraseña del administrador (obligatoria)."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "ID de la subred donde se conectará la NIC."
+  type        = string
+}
+
+variable "private_ip_address" {
+  description = "IP privada estática (opcional)."
+  type        = string
+  default     = null
+}
+
+variable "private_ip_address_allocation" {
+  description = "Modo de asignación cuando private_ip_address es null (Dynamic/Static)."
+  type        = string
+  default     = "Dynamic"
+}
+
+variable "enable_public_ip" {
+  description = "Si true, crea y asocia una IP pública. Por defecto las VMs nacen sin IP pública."
+  type        = bool
+  default     = false
+}
+
+variable "public_ip_sku" {
+  description = "SKU de la IP pública."
+  type        = string
+  default     = "Standard"
+}
+
+variable "public_ip_allocation_method" {
+  description = "Asignación de la IP pública (Static o Dynamic)."
+  type        = string
+  default     = "Static"
+}
+
+variable "public_ip_domain_name_label" {
+  description = "Etiqueta DNS para la IP pública (opcional)."
+  type        = string
+  default     = null
+}
+
+variable "network_security_group_id" {
+  description = "ID de un NSG para asociar a la NIC (opcional)."
+  type        = string
+  default     = null
+}
+
+variable "source_image_id" {
+  description = "ID de la imagen en Azure Compute Gallery."
+  type        = string
+}
+
+variable "os_disk" {
+  description = "Configuración del disco del sistema operativo."
+  type = object({
+    caching              = string
+    storage_account_type = string
+    disk_size_gb         = number
+  })
+  default = {
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+    disk_size_gb         = 128
+  }
+}
+
+variable "tags" {
+  description = "Etiquetas estándar del proyecto."
+  type = object({
+    UDN      = string
+    OWNER    = string
+    xpeowner = string
+    proyecto = string
+    ambiente = string
+  })
+}

--- a/modules/virtual_machine/versions.tf
+++ b/modules/virtual_machine/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable virtual machine module that provisions NICs, optional public IPs, and Linux or Windows VMs
- enforce password authentication, trusted launch security settings, and gallery image IDs for the VMs
- document module usage in the root example configuration

## Testing
- not run (terraform CLI not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d70a020f38832b98110264e42d4d01