### PR TITLE
Set Windows as default OS type for VM module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -437,7 +437,8 @@
 #   resource_group_name = module.resource_group_xpeterraformpoc2.resource_group_name
 #   location            = module.resource_group_xpeterraformpoc2.resource_group_location
 #   vm_size             = "Standard_DS2_v2"
-#   os_type             = "linux"
+#   # os_type es opcional; por defecto se aprovisiona Windows.
+#   # os_type             = "windows"
 #   admin_username      = "azureuser"
 #   admin_password      = "C0mpleja!1234"
 #

--- a/modules/virtual_machine/variables.tf
+++ b/modules/virtual_machine/variables.tf
@@ -19,8 +19,9 @@ variable "vm_size" {
 }
 
 variable "os_type" {
-  description = "Sistema operativo: \"linux\" o \"windows\"."
+  description = "Sistema operativo: \"linux\" o \"windows\". Por defecto se despliega Windows."
   type        = string
+  default     = "windows"
 
   validation {
     condition     = contains(["linux", "windows"], lower(var.os_type))


### PR DESCRIPTION
## Summary
- set the virtual machine module's `os_type` variable default to Windows and document the default
- update the module usage example to reflect Windows as the default operating system

## Testing
- terraform plan *(fails: terraform is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d714b13258832b8b013d1d6f059ac8