### PR TITLE
feat: Agregar nombre real de recursos de Azure en resumen de workflow

### DIFF
--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -75,9 +75,10 @@ jobs:
           if [ "$CREATES" -gt 0 ]; then
             echo "### ✅ Recursos a Crear" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Tipo | Nombre | Dirección |" >> $GITHUB_STEP_SUMMARY
-            echo "|------|--------|-----------|" >> $GITHUB_STEP_SUMMARY
-            jq -r '.resource_changes[]? | select(.change.actions[] == "create") | "| \(.type) | \(.name) | \(.address) |"' tfplan.json >> $GITHUB_STEP_SUMMARY
+            echo "| Tipo | Nombre en Azure | Nombre Terraform | Dirección |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|-----------------|------------------|-----------|" >> $GITHUB_STEP_SUMMARY
+            jq -r '.resource_changes[]? | select(.change.actions[] == "create") |
+              "| \(.type) | \(.change.after.name // .change.after.resource_group_name // .change.after.vnet_name // "N/A") | \(.name) | \(.address) |"' tfplan.json >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
@@ -85,9 +86,10 @@ jobs:
           if [ "$UPDATES" -gt 0 ]; then
             echo "### 🔄 Recursos a Modificar" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Tipo | Nombre | Dirección |" >> $GITHUB_STEP_SUMMARY
-            echo "|------|--------|-----------|" >> $GITHUB_STEP_SUMMARY
-            jq -r '.resource_changes[]? | select(.change.actions[] == "update") | "| \(.type) | \(.name) | \(.address) |"' tfplan.json >> $GITHUB_STEP_SUMMARY
+            echo "| Tipo | Nombre en Azure | Nombre Terraform | Dirección |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|-----------------|------------------|-----------|" >> $GITHUB_STEP_SUMMARY
+            jq -r '.resource_changes[]? | select(.change.actions[] == "update") |
+              "| \(.type) | \(.change.after.name // .change.after.resource_group_name // .change.after.vnet_name // "N/A") | \(.name) | \(.address) |"' tfplan.json >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 


### PR DESCRIPTION
- Agregar columna 'Nombre en Azure' en tablas de resumen
- Extraer nombre real del recurso desde plan JSON (name, resource_group_name, vnet_name)
- Mantener columna 'Nombre Terraform' con nombre lógico
- Mostrar nombre que aparecerá en Azure Portal en lugar de solo nombre lógico