### PR TITLE
feat: Update VNet peerings for SailPoint QA and PRD to use remote gat…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -156,13 +156,13 @@ module "xpe-vneticmsqlmidb-prd" {
         allow_virtual_network_access = true
         allow_forwarded_traffic      = true
         allow_gateway_transit        = false
-        use_remote_gateways          = false
+        use_remote_gateways          = true
       }
 
       remote = {
         allow_virtual_network_access = true
         allow_forwarded_traffic      = true
-        allow_gateway_transit        = false
+        allow_gateway_transit        = true
         use_remote_gateways          = false
       }
     }
@@ -207,13 +207,13 @@ module "xpe-vneticmsqlmidb-prd" {
          allow_virtual_network_access = true
          allow_forwarded_traffic      = true
          allow_gateway_transit        = false
-         use_remote_gateways          = false
+         use_remote_gateways          = true
        }
 
        remote = {
          allow_virtual_network_access = true
          allow_forwarded_traffic      = true
-         allow_gateway_transit        = false
+         allow_gateway_transit        = true
          use_remote_gateways          = false
        }
      }


### PR DESCRIPTION
…eway

- Enable use_remote_gateways on local side for both SailPoint VNets
- Enable allow_gateway_transit on remote side (vnet-xpe-seg-core)
- This allows SailPoint VNets to use the gateway in the hub VNet

https://claude.ai/code/session_01Rdkv4YJHnYucc9v9RvdBW1